### PR TITLE
Fix automated tests

### DIFF
--- a/.github/workflows/lint-cuda.yml
+++ b/.github/workflows/lint-cuda.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Lint with clang-tidy and clang-format
       run: |
         ./scripts/lint-cuda.sh

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable
         with:
           options: "--check --diff"

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, gpu]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/test-cuda.yml
+++ b/.github/workflows/test-cuda.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted, Linux, X64, gpu]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Test with GoogleTest
       run: |
         ./scripts/test-cuda.sh

--- a/tests/fixtures/generated_input_data_and_results.py
+++ b/tests/fixtures/generated_input_data_and_results.py
@@ -56,7 +56,7 @@ def run_pcalg_if_needed(current_dir: str, dataset_dir: str, dataset_name: str):
         "_zMin.txt",
         "_max.ord.txt",
         "_n.edgetests.txt",
-        "pMax.txt",
+        "_pMax.txt",
     ]
     files_that_need_to_be_existent = [
         f"{dataset_dir}/pcalg_{dataset_name}{file_ending}"

--- a/tests/fixtures/generated_input_data_and_results.py
+++ b/tests/fixtures/generated_input_data_and_results.py
@@ -48,9 +48,20 @@ generated_test_data_configs = [
     )
 ]
 
+
 def run_pcalg_if_needed(current_dir: str, dataset_dir: str, dataset_name: str):
-    file_endings = ["_graph.gml", "_sepset.txt", "_zMin.txt", "_max.ord.txt", "_n.edgetests.txt", "pMax.txt"]
-    files_that_need_to_be_existent = [f"{dataset_dir}/pcalg_{dataset_name}{file_ending}" for file_ending in file_endings]
+    file_endings = [
+        "_graph.gml",
+        "_sepset.txt",
+        "_zMin.txt",
+        "_max.ord.txt",
+        "_n.edgetests.txt",
+        "pMax.txt",
+    ]
+    files_that_need_to_be_existent = [
+        f"{dataset_dir}/pcalg_{dataset_name}{file_ending}"
+        for file_ending in file_endings
+    ]
 
     if not all([os.path.isfile(file) for file in files_that_need_to_be_existent]):
         os.system(

--- a/tests/fixtures/generated_input_data_and_results.py
+++ b/tests/fixtures/generated_input_data_and_results.py
@@ -48,6 +48,16 @@ generated_test_data_configs = [
     )
 ]
 
+def run_pcalg_if_needed(current_dir: str, dataset_dir: str, dataset_name: str):
+    file_endings = ["_graph.gml", "_sepset.txt", "_zMin.txt", "_max.ord.txt", "_n.edgetests.txt", "pMax.txt"]
+    files_that_need_to_be_existent = [f"{dataset_dir}/pcalg_{dataset_name}{file_ending}" for file_ending in file_endings]
+
+    if not all([os.path.isfile(file) for file in files_that_need_to_be_existent]):
+        os.system(
+            f"cd {current_dir}/../.. && ./scripts/use_pcalg_gaussian.R {dataset_name}"
+        )
+        os.system(f"cd {current_dir}")
+
 
 def generate_input_data_and_results_if_needed(
     manm_cs_parameters: str, write_gpucsl=False
@@ -65,11 +75,7 @@ def generate_input_data_and_results_if_needed(
         print(generate_command)
         os.system(generate_command)
 
-    if not os.path.isfile(f"{dataset_dir}/pcalg_{dataset_name}_graph.gml"):
-        os.system(
-            f"cd {current_dir}/../.. && ./scripts/use_pcalg_gaussian.R {dataset_name}"
-        )
-        os.system(f"cd {current_dir}")
+    run_pcalg_if_needed(current_dir, dataset_dir, dataset_name)
 
     if not os.path.isfile(f"{dataset_dir}/.gitignore"):
         os.system(f'echo "*" > {dataset_dir}/.gitignore')


### PR DESCRIPTION
- bumps checkout@v2 to checkout@v3, as checkout@v2 uses deprecated nodejs12 version
- checks for all files that are written by pcal script, and reruns it if one is missing
Previously, we only checked for one specific file.